### PR TITLE
Override particle colors for scythes depending on style used

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,14 @@ group = mod_group_id
 
 repositories {
     mavenLocal()
+    maven {
+        name = "Modrinth"
+        url = "https://api.modrinth.com/maven"
+        content {
+            // Malum
+            includeGroup "maven.modrinth"
+        }
+    }
 }
 
 base {
@@ -33,12 +41,14 @@ neoForge {
         client {
             client()
             systemProperty 'neoforge.enabledGameTestNamespaces', project.mod_id
+            systemProperty 'mixin.debug.export', 'true'
         }
 
         server {
             server()
             programArgument '--nogui'
             systemProperty 'neoforge.enabledGameTestNamespaces', project.mod_id
+            systemProperty 'mixin.debug.export', 'true'
         }
 
         gameTestServer {
@@ -93,6 +103,11 @@ dependencies {
     // For more info:
     // http://www.gradle.org/docs/current/userguide/artifact_dependencies_tutorial.html
     // http://www.gradle.org/docs/current/userguide/dependency_management.html
+
+    implementation "maven.modrinth:vanity-core:${vanity_version}"
+
+    implementation "maven.modrinth:LodestoneLib:${lodestone_version}"
+    implementation "maven.modrinth:Malum:${malum_version}"
 }
 
 var generateModMetadata = tasks.register("generateModMetadata", ProcessResources) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ parchment_minecraft_version=1.21.1
 parchment_mappings_version=2024.11.13
 minecraft_version=1.21.1
 minecraft_version_range=[1.21.1,1.22)
-neo_version=21.1.118
+neo_version=21.1.233
 neo_version_range=[21.1.0,)
 loader_version_range=[4,)
 
@@ -18,3 +18,8 @@ mod_version=1.0.2
 mod_group_id=gronglegrowth.vestis
 mod_authors=EsetKalenko (implementation), ShesaRamblingRose (art)
 mod_description=An addon to Sammy;'s Malum which uses Vanity to add additional cosmetics to equipment.
+
+## Dependencies
+vanity_version=QAqYAkRv
+lodestone_version=1.8.2
+malum_version=1.8.2

--- a/src/main/java/com/gronglegrowth/vestis/Vestis.java
+++ b/src/main/java/com/gronglegrowth/vestis/Vestis.java
@@ -12,6 +12,6 @@ public class Vestis
 
     public Vestis()
     {
-
+        VestisAssetTypes.init();
     }
 }

--- a/src/main/java/com/gronglegrowth/vestis/VestisAssetTypes.java
+++ b/src/main/java/com/gronglegrowth/vestis/VestisAssetTypes.java
@@ -1,0 +1,13 @@
+package com.gronglegrowth.vestis;
+
+import tech.thatgravyboat.vanity.api.style.AssetType;
+import tech.thatgravyboat.vanity.api.style.AssetTypes;
+
+public class VestisAssetTypes
+{
+	public static AssetType MALUM_SPIRIT = AssetTypes.register("malum_spirit");
+	
+	public static void init()
+	{
+	}
+}

--- a/src/main/java/com/gronglegrowth/vestis/VestisModifySpiritColor.java
+++ b/src/main/java/com/gronglegrowth/vestis/VestisModifySpiritColor.java
@@ -1,0 +1,26 @@
+package com.gronglegrowth.vestis;
+
+import com.sammy.malum.core.systems.spirit.type.SpiritLike;
+import com.sammy.malum.registry.common.magic.MalumSpiritTypes;
+import net.minecraft.world.item.ItemStack;
+import tech.thatgravyboat.vanity.api.design.DesignManager;
+
+public class VestisModifySpiritColor
+{
+	public static SpiritLike modify(
+			SpiritLike current,
+			ItemStack itemStack
+	)
+	{
+		var style = DesignManager.client().getStyleFromItem(itemStack);
+		if(style != null && style.hasAsset(VestisAssetTypes.MALUM_SPIRIT))
+		{
+			var assetId = style.asset(VestisAssetTypes.MALUM_SPIRIT);
+			if(MalumSpiritTypes.SPIRIT_TYPES_REGISTRY.containsKey(assetId))
+			{
+				return MalumSpiritTypes.SPIRIT_TYPES_REGISTRY.get(assetId);
+			}
+		}
+		return current;
+	}
+}

--- a/src/main/java/com/gronglegrowth/vestis/mixin/ScytheBoomerangRendererMixin.java
+++ b/src/main/java/com/gronglegrowth/vestis/mixin/ScytheBoomerangRendererMixin.java
@@ -1,0 +1,30 @@
+package com.gronglegrowth.vestis.mixin;
+
+import com.gronglegrowth.vestis.VestisModifySpiritColor;
+import com.sammy.malum.client.renderer.entity.scythe.ScytheBoomerangEntityRenderer;
+import com.sammy.malum.common.entity.scythe.ScytheBoomerangEntity;
+import com.sammy.malum.core.systems.spirit.type.SpiritLike;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+@Mixin(
+		value = ScytheBoomerangEntityRenderer.class,
+		remap = false
+)
+public class ScytheBoomerangRendererMixin
+{
+	@ModifyVariable(
+			method = "render(Lcom/sammy/malum/common/entity/scythe/ScytheBoomerangEntity;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V",
+			at = @At("STORE"),
+			name = "spirit"
+	)
+	private SpiritLike modifySpiritType(
+			SpiritLike value,
+			ScytheBoomerangEntity entityIn
+	)
+	{
+		var itemStack = entityIn.getItem();
+		return VestisModifySpiritColor.modify(value, itemStack);
+	}
+}

--- a/src/main/java/com/gronglegrowth/vestis/mixin/WeaponParticleEffectsMixin.java
+++ b/src/main/java/com/gronglegrowth/vestis/mixin/WeaponParticleEffectsMixin.java
@@ -1,0 +1,30 @@
+package com.gronglegrowth.vestis.mixin;
+
+import com.gronglegrowth.vestis.VestisModifySpiritColor;
+import com.sammy.malum.common.entity.scythe.AbstractScytheProjectileEntity;
+import com.sammy.malum.core.systems.spirit.type.SpiritLike;
+import com.sammy.malum.visual_effects.WeaponParticleEffects;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+@Mixin(
+		value = WeaponParticleEffects.class,
+		remap = false
+)
+public class WeaponParticleEffectsMixin
+{
+	@ModifyVariable(
+			method = "spawnMaelstromParticles",
+			at = @At("STORE"),
+			name = "spirit"
+	)
+	private static SpiritLike modifySpiritType(
+			SpiritLike value,
+			AbstractScytheProjectileEntity entity
+	)
+	{
+		var itemStack = entity.getItem();
+		return VestisModifySpiritColor.modify(value, itemStack);
+	}
+}

--- a/src/main/resources/META-INF/neoforge.mods.toml
+++ b/src/main/resources/META-INF/neoforge.mods.toml
@@ -10,6 +10,9 @@ displayName="Malum: Vestis"
 authors="EsetKalenko (implementation), ShesaRamblingRose (art)"
 description='''An addon to Sammy;'s Malum which uses Vanity to add additional cosmetics to equipment.'''
 
+[[mixins]]
+config = "vestis.mixins.json"
+
 [[dependencies.vestis]]
     modId="neoforge"
     type="required"

--- a/src/main/resources/data/vestis/vanity/designs/scythes.json
+++ b/src/main/resources/data/vestis/vanity/designs/scythes.json
@@ -8,7 +8,8 @@
         "tag": "malum:scythe",
         "assets": {
           "default": "vestis:scythes/sacred_scythe",
-          "hand": "vestis:scythes/sacred_scythe_handheld"
+          "hand": "vestis:scythes/sacred_scythe_handheld",
+          "malum_spirit": "malum:sacred"
         }
       }
     ],
@@ -17,7 +18,8 @@
         "tag": "malum:scythe",
         "assets": {
           "default": "vestis:scythes/arcane_scythe",
-          "hand": "vestis:scythes/arcane_scythe_handheld"
+          "hand": "vestis:scythes/arcane_scythe_handheld",
+          "malum_spirit": "malum:arcane"
         }
       }
     ],
@@ -26,7 +28,8 @@
         "tag": "malum:scythe",
         "assets": {
           "default": "vestis:scythes/aqueous_scythe",
-          "hand": "vestis:scythes/aqueous_scythe_handheld"
+          "hand": "vestis:scythes/aqueous_scythe_handheld",
+          "malum_spirit": "malum:aqueous"
         }
       }
     ],
@@ -35,7 +38,8 @@
         "tag": "malum:scythe",
         "assets": {
           "default": "vestis:scythes/aerial_scythe",
-          "hand": "vestis:scythes/aerial_scythe_handheld"
+          "hand": "vestis:scythes/aerial_scythe_handheld",
+          "malum_spirit": "malum:aerial"
         }
       }
     ],
@@ -44,7 +48,8 @@
         "tag": "malum:scythe",
         "assets": {
           "default": "vestis:scythes/earthen_scythe",
-          "hand": "vestis:scythes/earthen_scythe_handheld"
+          "hand": "vestis:scythes/earthen_scythe_handheld",
+          "malum_spirit": "malum:earthen"
         }
       }
     ],
@@ -53,7 +58,8 @@
         "tag": "malum:scythe",
         "assets": {
           "default": "vestis:scythes/eldritch_scythe",
-          "hand": "vestis:scythes/eldritch_scythe_handheld"
+          "hand": "vestis:scythes/eldritch_scythe_handheld",
+          "malum_spirit": "malum:eldritch"
         }
       }
     ],
@@ -62,7 +68,8 @@
         "tag": "malum:scythe",
         "assets": {
           "default": "vestis:scythes/infernal_scythe",
-          "hand": "vestis:scythes/infernal_scythe_handheld"
+          "hand": "vestis:scythes/infernal_scythe_handheld",
+          "malum_spirit": "malum:infernal"
         }
       }
     ],
@@ -71,7 +78,8 @@
         "tag": "malum:scythe",
         "assets": {
           "default": "vestis:scythes/wicked_scythe",
-          "hand": "vestis:scythes/wicked_scythe_handheld"
+          "hand": "vestis:scythes/wicked_scythe_handheld",
+          "malum_spirit": "malum:wicked"
         }
       }
     ]

--- a/src/main/resources/vestis.mixins.json
+++ b/src/main/resources/vestis.mixins.json
@@ -1,0 +1,14 @@
+{
+    "required": true,
+    "minVersion": "0.8",
+    "package": "com.gronglegrowth.vestis.mixin",
+    "compatibilityLevel": "JAVA_21",
+    "mixins": [],
+    "client": [
+        "ScytheBoomerangRendererMixin",
+        "WeaponParticleEffectsMixin"
+    ],
+    "injectors": {
+        "defaultRequire": 1
+    }
+}


### PR DESCRIPTION
Do note that the colors are defined by the spirit type. Malum uses these to determine particle colors, and figured it'd be easiest to implement to just keep it that way. Plus, these scythes are already designed with specific spirits in mind, so it works out nicely!

One thing to note, is that I have included vanity core, malum, and lodestone as dependencies in the project. I'm not aware of any repository that these would be available in, so I simply used the modrinth maven repo. Thus the strange version property value for vanity.